### PR TITLE
Use Ember.set when writing to service

### DIFF
--- a/addon/components/memory-scroll.js
+++ b/addon/components/memory-scroll.js
@@ -18,6 +18,6 @@ export default Ember.Component.extend({
   },
   willDestroyElement: function() {
     var position = this.$().scrollTop();
-    this.get('memory')[this.get('key')] = position;
+    Ember.set(this.get('memory'), this.get('key'), position);
   }
 });


### PR DESCRIPTION
Avoids `Assertion Failed: You must use Ember.set() to set the...` error... At least it got rid of the error for me (running Ember 1.13.10).
