### PR TITLE
Adds memory scroll to components that aren't destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Example:
 {{/memory-scroll}}
 ```
 
-If your component is not destroyed
+
+if you have a component that isn't destroyed.
 
 ```handlebars
 {{#memory-scroll key="my-fancy-pane" memoryEvent="onScroll"}}

--- a/README.md
+++ b/README.md
@@ -17,11 +17,23 @@ Example:
 {{/memory-scroll}}
 ```
 
+If your component is not destroyed
+
+```handlebars
+{{#memory-scroll key="my-fancy-pane" memoryEvent="onScroll"}}
+  {{#each items as |item|}}
+    {{#link-to "detail" item}}{{item.id}}: {{item.value}}{{/link-to}}
+  {{/each}}
+{{/memory-scroll}}
+```
+
 `{{memory-scroll}}` does just two things: when its about to be
-destroyed it saves its element's scroll position into a Service (which
+destroyed or in event scroll - `when you set memoryEvent="onScroll"` - it saves its element's scroll position into a Service (which
 is Ember's standard way to maintain long-lived application state). And
 when it's just been rendered, it looks in the service to see if it
 should set its scroll position.
+
+
 
 All the rest is up to you, so it's easy to use as a drop-in
 replacement for any `<div>` that is already styled for scrolling.

--- a/addon/components/base.js
+++ b/addon/components/base.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   didInsertElement() {
     this._super(...arguments);
     if (this.get('memoryEvent') === 'onScroll') {
-      this.$().on('scroll', this, this.onScroll.bind(this));
+      this.targetElement().on('scroll', this, this.onScroll.bind(this));
     }
   },
 
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     if (this.get('memoryEvent') === 'onScroll') {
-      this.$().off('scroll', this, this.onScroll.bind(this));
+      this.targetElement().off('scroll', this, this.onScroll.bind(this));
     } else {
       this.remember(this.get('key'));
     }

--- a/addon/components/base.js
+++ b/addon/components/base.js
@@ -29,10 +29,9 @@ export default Ember.Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
+    this.remember(this.get('key'));
     if (this.get('memoryEvent') === 'onScroll') {
       this.targetElement().off('scroll', this, this.onScroll.bind(this));
-    } else {
-      this.remember(this.get('key'));
     }
   },
 

--- a/addon/components/base.js
+++ b/addon/components/base.js
@@ -3,7 +3,19 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   memory: Ember.inject.service('memory-scroll'),
 
+  didInsertElement() {
+    this._super(...arguments);
+    if (this.get('memoryEvent') === 'onScroll') {
+      this.$().on('scroll', this, this.onScroll.bind(this));
+    }
+  },
+
+  onScroll() {
+   this.remember(this.get('key'));
+  },
+
   didRender() {
+    this._super(...arguments);
     let key = this.get('key');
     if (!key) {
       throw new Error("You must provide a key to memory-scroll like {{memory-scroll key=\"my-awesome-pane\"}}.");
@@ -16,7 +28,12 @@ export default Ember.Component.extend({
   },
 
   willDestroyElement() {
-    this.remember(this.get('key'));
+    this._super(...arguments);
+    if (this.get('memoryEvent') === 'onScroll') {
+      this.$().off('scroll', this, this.onScroll.bind(this));
+    } else {
+      this.remember(this.get('key'));
+    }
   },
 
   remember(key) {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 export default Ember.Controller.extend({
+  conversationKey: 'one',
   items: Ember.computed(function() {
     let output = [];
     for (let i = 0; i < 10; i++) {
@@ -8,5 +9,10 @@ export default Ember.Controller.extend({
       });
     }
     return output;
-  })
+  }),
+  actions: {
+    changeConversation(conversationKey) {
+      this.set('conversationKey', conversationKey);
+    }
+  }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,9 @@
-{{#memory-scroll class="item-container" key="index-items"}}
+<h2>Conversations example</h2>
+  <a href="" {{action "changeConversation" 'one'}}>Conversation One</a>
+  <a href="" {{action "changeConversation" 'two'}}>Conversation Two</a>
+
+<h4>You are in conversation {{conversationKey}}</h4>
+{{#memory-scroll class="item-container" key=conversationKey memoryEvent="onScroll"}}
   {{#each items as |item|}}
     {{#link-to "detail" item}}<span data-item-id={{item.id}}>{{item.id}}</span>{{/link-to}}
   {{/each}}

--- a/tests/integration/components/memory-scroll-test.js
+++ b/tests/integration/components/memory-scroll-test.js
@@ -97,3 +97,45 @@ test('it preserves independent scroll positions per key when key changes', funct
   this.set('showIt', 'first');
   assert.equal(this.$('.sample').scrollTop(), 50);
 });
+
+
+test('it preserves independent scroll when use memory event as onScroll and change data down', function(assert) {
+  this.render(hbs`
+    <style type="text/css">
+      .sample {
+        height: 30px;
+        overflow-y: scroll;
+      }
+      .sample > div {
+        height: 100px;
+      }
+    </style>
+
+    {{#if showIt}}
+      {{#memory-scroll key=showIt memoryEvent="onScroll" class="sample"}}
+        <div>
+          sample content
+          {{#each items as |item|}}
+            <p class="item-list">{{item.id}}</p>
+          {{/each}}
+        </div>
+      {{/memory-scroll}}
+    {{/if}}
+  `);
+
+  this.set('showIt', 'first');
+  assert.equal(this.$('.sample').text().trim(), 'sample content');
+  this.$('.sample').scrollTop(50);
+  this.set('items', [{id: 1}]);
+  this.set('showIt', 'second');
+  this.set('items', [{id:4}]);
+  this.$('.sample').scrollTop(20);
+  this.set('showIt', 'first');
+  this.set('items', [{id: 1}]);
+  assert.equal(this.$('.item-list').text().trim(), '1');
+  assert.equal(this.$('.sample').scrollTop(), 50);
+  this.set('showIt', 'second');
+  this.set('items', [{id:4}]);
+  assert.equal(this.$('.item-list').text().trim(), '4');
+  assert.equal(this.$('.sample').scrollTop(), 20);
+});


### PR DESCRIPTION
Following this issue #2
I created a mode to use `memory-scroll` in scenario where you need keep scroll but your component isn't  `destroyed` every time you want to save the state
