### PR TITLE
Update ember-cli-babel to ^6.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-deploy-build": "1.1.0",
     "ember-cli-deploy-ghpages": "0.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^1.4.0",
@@ -46,7 +46,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.8.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
We need to leave babel5 behind to be able to (eventually) drop ember-cli-shims